### PR TITLE
feat: Enhance visual polish with Google Fonts and accent color

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,10 @@
     -->
     <!-- <meta http-equiv="refresh" content="0; url=PUT_YOUR_REDIRECT_URL_HERE"> -->
 
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@700&family=Open+Sans:wght@400&display=swap" rel="stylesheet">
+
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="style.css">
 </head>
@@ -32,19 +36,19 @@
         <div class="tool-grid">
             <div class="tool-card">
                 <h3><i class="fa fa-cube" aria-hidden="true"></i> <a href="https://melbinjp.github.io/3d_modelview/" target="_blank">3D Model Viewer</a></h3>
-                <!-- Optional: <p>Short description of the tool.</p> -->
+                <p>Interactively view and manipulate 3D models directly in your browser.</p>
             </div>
             <div class="tool-card">
                 <h3><i class="fa fa-microphone" aria-hidden="true"></i> <a href="https://melbinjp.github.io/Transcribe-Realtime-/" target="_blank">Live Audio Transcription</a></h3>
-                <!-- Optional: <p>Short description of the tool.</p> -->
+                <p>Transcribe spoken audio into text in real-time with high accuracy.</p>
             </div>
             <div class="tool-card">
                 <h3><i class="fa fa-youtube-play" aria-hidden="true"></i> <a href="https://youtube.com/@video_gen?feature=shared" target="_blank">VideoGen YouTube Channel</a></h3>
-                <!-- Optional: <p>Short description of the tool.</p> -->
+                <p>Explore AI-generated video content and experiments on our official channel.</p>
             </div>
             <div class="tool-card">
                 <h3><i class="fa fa-video-camera" aria-hidden="true"></i> <a href="https://melbinjp.github.io/AV-Recorder/" target="_blank">AV Recorder</a></h3>
-                <!-- Optional: <p>Short description of the tool.</p> -->
+                <p>Easily record audio and video from your browser, ready for download.</p>
             </div>
         </div>
     </main>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,10 @@
+:root {
+    --accent-color: #007bff; /* A refined blue, chosen as a starting point */
+}
+
 /* General Body Styles */
 body {
-    font-family: Arial, Helvetica, sans-serif;
+    font-family: 'Open Sans', sans-serif;
     background-color: #f0f2f5;
     color: #333;
     margin: 0;
@@ -13,11 +17,12 @@ header {
     background-color: #ffffff;
     padding: 20px 0;
     text-align: center;
-    border-bottom: 1px solid #ddd;
+    border-bottom: 2px solid var(--accent-color);
     box-shadow: 0 2px 4px rgba(0,0,0,0.05);
 }
 
 header h1 {
+    font-family: 'Montserrat', sans-serif;
     margin: 0;
     font-size: 2em;
     color: #333;
@@ -26,7 +31,7 @@ header h1 {
 /* Featured Tool Section */
 #featured-tool {
     background-color: #ffffff;
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--accent-color);
     margin: 20px;
     padding: 30px;
     min-height: 150px; /* Noticeable even when empty */
@@ -70,25 +75,47 @@ main {
 }
 
 .tool-card h3 {
+    font-family: 'Montserrat', sans-serif;
     margin-top: 0;
-    color: #333;
+    color: #333; /* Heading text color remains default */
+}
+
+.tool-card h3 .fa {
+    color: var(--accent-color);
 }
 
 .tool-card p {
+    font-family: 'Open Sans', sans-serif; /* Explicitly set, though inherited */
     font-size: 0.9em;
     color: #555;
     flex-grow: 1; /* Allows paragraph to take available space */
+    margin-top: 10px; /* Space between heading and paragraph */
+    margin-bottom: 15px; /* Space between paragraph and link */
+    line-height: 1.5; /* Improved readability */
 }
 
+.tool-card h3 a { /* More specific selector for links within h3 */
+    text-decoration: none;
+    color: var(--accent-color); /* Apply accent color to link text */
+    font-weight: bold;
+    /* display: inline-block; already on .tool-card a, but h3 a might not need it if h3 is block */
+    /* margin-top: 10px; Not needed here as it's part of h3 flow */
+}
+
+.tool-card h3 a:hover {
+    text-decoration: underline; /* Or a slightly darker shade of accent */
+}
+
+/* General link style within tool-card if any outside h3, can be kept or removed if not needed */
 .tool-card a {
     text-decoration: none;
-    color: #007bff;
+    color: #007bff; /* This was the old color, could be var(--accent-color) or another default */
     font-weight: bold;
     display: inline-block; /* Ensures padding and margin are respected */
-    margin-top: 10px; /* Space between text and link */
+    margin-top: 10px; /* Space between text and link - this is for links *not* in h3 */
 }
 
-.tool-card a:hover {
+.tool-card a:hover { /* General hover for links not in h3 */
     text-decoration: underline;
 }
 


### PR DESCRIPTION
This commit applies further visual refinements to the homepage:

- **Typography:**
    - Integrated Google Fonts: - Montserrat (Bold 700) for headings (main title, tool card titles). - Open Sans (Regular 400) for body text (general text, tool card descriptions).
    - Updated `index.html` to link the fonts and `style.css` to apply them.

- **Accent Color:**
    - Introduced a CSS custom variable `--accent-color` (set to `#007bff`).
    - Applied this accent color to:
        - Tool card icons.
        - Tool card links. - Header bottom border. - Featured tool section border.

These changes aim to create a more sophisticated, professional, and "best company in the world" aesthetic, improving readability and visual appeal.