### PR TITLE
fix(ci): Add write permissions to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
The GitHub Actions workflow was failing with a permissions error because the default GITHUB_TOKEN does not have write access to the repository.

This commit adds the `permissions: contents: write` block to the `build-and-deploy` job in the `deploy.yml` workflow file. This grants the action the necessary permissions to push the built site to the `gh-pages` branch, enabling successful automated deployments.